### PR TITLE
improve logic for finding sender

### DIFF
--- a/content.js
+++ b/content.js
@@ -2,16 +2,16 @@
 function findSender(element) {
   let current = element;
   while (current && current !== document.body) {
-    // Look for h5.html-h5 within this ancestor
-    const h5 = current.querySelector && current.querySelector('h5.html-h5');
-    if (h5) {
-      const span = h5.querySelector('span');
-      if (span) {
-        if (span.textContent.trim().toLowerCase().includes('you sent')) {
+    // Look for the lowest common ancestor of the sender and the content within `current`
+    const msgDiv = current.querySelector?.('div.x78zum5.xdt5ytf.x1n2onr6[role="gridcell"]');
+    if (msgDiv) {
+      const senderSpan = msgDiv.querySelector('span');
+      if (senderSpan) {
+        const sender = senderSpan.textContent.trim();
+        if (sender.toLowerCase().includes('you sent')) {
           return 'You';
-        } else {
-          return span.textContent.trim();
         }
+        return sender;
       }
     }
     current = current.parentElement;


### PR DESCRIPTION
Hey Neil! 👋

I wanted to share a small improvement for your awesome plugin!

While trying it, I noticed an edge case with message sender detection. When I send multiple consecutive messages that exceed the viewport height, then scroll up and down, the plugin sometimes struggles to tell that the messages currently within the viewport are from me.

Here's what it currently looks like:

https://github.com/user-attachments/assets/764ad92b-a547-4973-b684-21458d40e5f8

And with the change in this PR:

https://github.com/user-attachments/assets/9b846f59-2165-4299-8840-791451f5ea1f

Let me know what you think. I'll be happy to discuss or make any adjustments if needed. Zot! 🐜